### PR TITLE
Updated docs to remove @3.4.0 version tag from tw install

### DIFF
--- a/src/routes/guide/installation/+page.svelte
+++ b/src/routes/guide/installation/+page.svelte
@@ -61,7 +61,7 @@
 <Spacer h={10} />
 <Snippet
 	width="550px"
-	text={[`${type} i -D tailwindcss@3.4.0 postcss autoprefixer`, "npx tailwindcss init -p"]}
+	text={[`${type} i -D tailwindcss postcss autoprefixer`, "npx tailwindcss init -p"]}
 	type="lite"
 />
 <Spacer h={20} />


### PR DESCRIPTION
## Description

Fixes #118

### Breaking changes

No breaking changes but please update to lastest version so you can use Tailwind 3.4.1 and later

## Checks 🗸

-   [x] My code is up to date with main
-   [x] My code requires a documentation change
-   [x] I have updated the documentation as required
-   [ ] My code requires a new package version to be created
-   [ ] I have updated the package version
-   [x] CI is passing
-   [x] The vercel deployment is passing and the page is working as expected
