### PR TITLE
Revert "Responsive modal"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "geist-ui-svelte",
-	"version": "0.6.15",
+	"version": "0.6.14",
 	"author": {
 		"name": "Aidan Bleser",
 		"url": "https://aidanbleser.com"

--- a/src/lib/modal/Modal.svelte
+++ b/src/lib/modal/Modal.svelte
@@ -60,11 +60,10 @@
 	data-show={visible}
 	aria-label={ariaLabel}
 	role="dialog"
-	style="max-height: calc(100svh - 20px);"
 	class="bg-gray-0 dark:bg-gray-999 border-t max-w-full w-full bottom-0 left-0 fixed sm:top-1/2 transition-all
     sm:-translate-x-1/2 sm:left-1/2 sm:-translate-y-1/2 z-50 data-[show=false]:opacity-0 data-[show=false]:sm:scale-90
 	data-[show=false]:pointer-events-none data-[show=false]:scale-95 sm:rounded-xl border-gray-100 sm:border
-	dark:border-gray-900 overflow-y-auto {className}"
+	dark:border-gray-900 {className}"
 >
 	<slot />
 </div>


### PR DESCRIPTION
Reverts ieedan/geist-ui-svelte#230

This breaks when using it with the select component.

Need to find a different way to fix overflow-y without causing unexpected behavior.