### PR TITLE
Adds support for `#` to tabs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
 	"name": "geist-ui-svelte",
-	"version": "0.7.4",
+	"version": "0.7.6",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "geist-ui-svelte",
-			"version": "0.7.4",
+			"version": "0.7.6",
 			"license": "MIT",
 			"dependencies": {
 				"@fontsource/geist-mono": "^5.0.3",
 				"@fontsource/geist-sans": "^5.0.3",
-				"@sveltejs/kit": "^2.5.7",
-				"@vercel/analytics": "^1.2.2",
+				"@sveltejs/kit": "^2.5.10",
+				"@vercel/analytics": "^1.3.0",
 				"@vercel/speed-insights": "^1.0.10",
 				"autoprefixer": "^10.4.19",
 				"class-variance-authority": "^0.7.0",
@@ -25,23 +25,23 @@
 				"tippy.js": "^6.3.7"
 			},
 			"devDependencies": {
-				"@cspell/eslint-plugin": "^8.8.0",
-				"@sveltejs/adapter-auto": "^3.2.0",
-				"@sveltejs/package": "^2.3.0",
-				"@sveltejs/vite-plugin-svelte": "^3.0.2",
+				"@cspell/eslint-plugin": "^8.8.3",
+				"@sveltejs/adapter-auto": "^3.2.1",
+				"@sveltejs/package": "^2.3.1",
+				"@sveltejs/vite-plugin-svelte": "^3.1.0",
 				"@types/eslint": "^8.56.10",
-				"@typescript-eslint/eslint-plugin": "^7.8.0",
-				"@typescript-eslint/parser": "^7.8.0",
+				"@typescript-eslint/eslint-plugin": "^7.10.0",
+				"@typescript-eslint/parser": "^7.10.0",
 				"eslint": "^8.57.0",
 				"eslint-config-prettier": "^9.1.0",
-				"eslint-plugin-svelte": "^2.38.0",
+				"eslint-plugin-svelte": "^2.39.0",
 				"prettier": "^3.2.5",
-				"prettier-plugin-svelte": "^3.2.2",
+				"prettier-plugin-svelte": "^3.2.3",
 				"publint": "^0.1.9",
-				"svelte": "^4.2.16",
+				"svelte": "^4.2.17",
 				"svelte-check": "^3.7.1",
 				"tslib": "^2.4.1",
-				"typescript": "^5.4.3",
+				"typescript": "^5.4.5",
 				"vite": "^5.2.11"
 			},
 			"peerDependencies": {
@@ -92,61 +92,62 @@
 			}
 		},
 		"node_modules/@cspell/cspell-bundled-dicts": {
-			"version": "8.8.0",
-			"resolved": "https://registry.npmjs.org/@cspell/cspell-bundled-dicts/-/cspell-bundled-dicts-8.8.0.tgz",
-			"integrity": "sha512-wK1qGhy6DiCj9LqGnMKutIQcMPD8J9oczM1sr3J+zmh6WggP1xkuCHu8XSxxO4Q2AOLdtcVW/4SXJ7gzT7Azbg==",
+			"version": "8.8.3",
+			"resolved": "https://registry.npmjs.org/@cspell/cspell-bundled-dicts/-/cspell-bundled-dicts-8.8.3.tgz",
+			"integrity": "sha512-nRa30TQwE4R5xcM6CBibM2l7D359ympexjm7OrykzYmStIiiudDIsuNOIXGBrDouxRFgKGAa/ETo1g+Pxz7kNA==",
 			"dev": true,
 			"dependencies": {
 				"@cspell/dict-ada": "^4.0.2",
-				"@cspell/dict-aws": "^4.0.1",
+				"@cspell/dict-aws": "^4.0.2",
 				"@cspell/dict-bash": "^4.1.3",
-				"@cspell/dict-companies": "^3.0.31",
-				"@cspell/dict-cpp": "^5.1.3",
+				"@cspell/dict-companies": "^3.1.0",
+				"@cspell/dict-cpp": "^5.1.6",
 				"@cspell/dict-cryptocurrencies": "^5.0.0",
 				"@cspell/dict-csharp": "^4.0.2",
 				"@cspell/dict-css": "^4.0.12",
 				"@cspell/dict-dart": "^2.0.3",
 				"@cspell/dict-django": "^4.1.0",
 				"@cspell/dict-docker": "^1.1.7",
-				"@cspell/dict-dotnet": "^5.0.0",
+				"@cspell/dict-dotnet": "^5.0.2",
 				"@cspell/dict-elixir": "^4.0.3",
-				"@cspell/dict-en_us": "^4.3.19",
-				"@cspell/dict-en-common-misspellings": "^2.0.0",
+				"@cspell/dict-en_us": "^4.3.20",
+				"@cspell/dict-en-common-misspellings": "^2.0.1",
 				"@cspell/dict-en-gb": "1.1.33",
-				"@cspell/dict-filetypes": "^3.0.3",
+				"@cspell/dict-filetypes": "^3.0.4",
 				"@cspell/dict-fonts": "^4.0.0",
 				"@cspell/dict-fsharp": "^1.0.1",
-				"@cspell/dict-fullstack": "^3.1.5",
+				"@cspell/dict-fullstack": "^3.1.8",
 				"@cspell/dict-gaming-terms": "^1.0.5",
 				"@cspell/dict-git": "^3.0.0",
-				"@cspell/dict-golang": "^6.0.5",
+				"@cspell/dict-golang": "^6.0.9",
+				"@cspell/dict-google": "^1.0.0",
 				"@cspell/dict-haskell": "^4.0.1",
 				"@cspell/dict-html": "^4.0.5",
 				"@cspell/dict-html-symbol-entities": "^4.0.0",
 				"@cspell/dict-java": "^5.0.6",
 				"@cspell/dict-julia": "^1.0.1",
-				"@cspell/dict-k8s": "^1.0.2",
+				"@cspell/dict-k8s": "^1.0.3",
 				"@cspell/dict-latex": "^4.0.0",
 				"@cspell/dict-lorem-ipsum": "^4.0.0",
 				"@cspell/dict-lua": "^4.0.3",
 				"@cspell/dict-makefile": "^1.0.0",
 				"@cspell/dict-monkeyc": "^1.0.6",
 				"@cspell/dict-node": "^5.0.1",
-				"@cspell/dict-npm": "^5.0.15",
-				"@cspell/dict-php": "^4.0.6",
-				"@cspell/dict-powershell": "^5.0.3",
+				"@cspell/dict-npm": "^5.0.16",
+				"@cspell/dict-php": "^4.0.7",
+				"@cspell/dict-powershell": "^5.0.4",
 				"@cspell/dict-public-licenses": "^2.0.6",
 				"@cspell/dict-python": "^4.1.11",
 				"@cspell/dict-r": "^2.0.1",
 				"@cspell/dict-ruby": "^5.0.2",
 				"@cspell/dict-rust": "^4.0.3",
-				"@cspell/dict-scala": "^5.0.0",
-				"@cspell/dict-software-terms": "^3.3.20",
+				"@cspell/dict-scala": "^5.0.2",
+				"@cspell/dict-software-terms": "^3.3.23",
 				"@cspell/dict-sql": "^2.1.3",
 				"@cspell/dict-svelte": "^1.0.2",
 				"@cspell/dict-swift": "^2.0.1",
 				"@cspell/dict-terraform": "^1.0.0",
-				"@cspell/dict-typescript": "^3.1.4",
+				"@cspell/dict-typescript": "^3.1.5",
 				"@cspell/dict-vue": "^3.0.0"
 			},
 			"engines": {
@@ -154,18 +155,18 @@
 			}
 		},
 		"node_modules/@cspell/cspell-pipe": {
-			"version": "8.8.0",
-			"resolved": "https://registry.npmjs.org/@cspell/cspell-pipe/-/cspell-pipe-8.8.0.tgz",
-			"integrity": "sha512-R9YEI8+GVa98mEMCtCHJMqX4xHNwhdHo31lGhmyUpYiuLcD9HZ96n+ExCGbnFBUXyugSHCmTA/lubdfo7CPZrw==",
+			"version": "8.8.3",
+			"resolved": "https://registry.npmjs.org/@cspell/cspell-pipe/-/cspell-pipe-8.8.3.tgz",
+			"integrity": "sha512-tzngpFKXeUsdTZEErffTlwUnPIKYgyRKy0YTrD77EkhyDSbUnaS8JWqtGZbKV7iQ+R4CL7tiaubPjUzkbWj+kQ==",
 			"dev": true,
 			"engines": {
 				"node": ">=18"
 			}
 		},
 		"node_modules/@cspell/cspell-resolver": {
-			"version": "8.8.0",
-			"resolved": "https://registry.npmjs.org/@cspell/cspell-resolver/-/cspell-resolver-8.8.0.tgz",
-			"integrity": "sha512-+o1fwkE36Wi8JTnjDHdLScB99U8YtLQ7XbnEe61Hj2ES1G5TsYCZ1r7RFCw2Kzn2qrkE2mnxknKwbf9h0Db4Ng==",
+			"version": "8.8.3",
+			"resolved": "https://registry.npmjs.org/@cspell/cspell-resolver/-/cspell-resolver-8.8.3.tgz",
+			"integrity": "sha512-pMOB2MJYeria0DeW1dsehRPIHLzoOXCm1Cdjp1kRZ931PbqNCYaE/GM6laWpUTAbS9Ly2tv4g0jK3PUH8ZTtJA==",
 			"dev": true,
 			"dependencies": {
 				"global-directory": "^4.0.1"
@@ -175,18 +176,18 @@
 			}
 		},
 		"node_modules/@cspell/cspell-service-bus": {
-			"version": "8.8.0",
-			"resolved": "https://registry.npmjs.org/@cspell/cspell-service-bus/-/cspell-service-bus-8.8.0.tgz",
-			"integrity": "sha512-BvQgBbrsXmKmaEXhXSGQPzBTM37EMk696u6+ThuJuIikP54pKJpUc7rOV1NKretxC32Mj37mS750X1YR02Z80w==",
+			"version": "8.8.3",
+			"resolved": "https://registry.npmjs.org/@cspell/cspell-service-bus/-/cspell-service-bus-8.8.3.tgz",
+			"integrity": "sha512-QVKe/JZvoTaaBAMXG40HjZib1g6rGgxk03e070GmdfCiMRUCWFtK+9DKVYJfSqjQhzj/eDCrq8aWplHWy66umg==",
 			"dev": true,
 			"engines": {
 				"node": ">=18"
 			}
 		},
 		"node_modules/@cspell/cspell-types": {
-			"version": "8.8.0",
-			"resolved": "https://registry.npmjs.org/@cspell/cspell-types/-/cspell-types-8.8.0.tgz",
-			"integrity": "sha512-CGIYttfpp0M/y4a7vfVQljeJqBcIsGYIM4iwJU+F3MQUqFqvNFeU58S27GfK5VzkMAJumsOnmJqSgm+h/g7n0Q==",
+			"version": "8.8.3",
+			"resolved": "https://registry.npmjs.org/@cspell/cspell-types/-/cspell-types-8.8.3.tgz",
+			"integrity": "sha512-31wYSBPinhqKi9TSzPg50fWHJmMQwD1d5p26yM/NAfNQvjAfBQlrg4pqix8pxOJkAK5W/TnoaVXjzJ5XCg6arQ==",
 			"dev": true,
 			"engines": {
 				"node": ">=18"
@@ -199,9 +200,9 @@
 			"dev": true
 		},
 		"node_modules/@cspell/dict-aws": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@cspell/dict-aws/-/dict-aws-4.0.1.tgz",
-			"integrity": "sha512-NXO+kTPQGqaaJKa4kO92NAXoqS+i99dQzf3/L1BxxWVSBS3/k1f3uhmqIh7Crb/n22W793lOm0D9x952BFga3Q==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-aws/-/dict-aws-4.0.2.tgz",
+			"integrity": "sha512-aNGHWSV7dRLTIn8WJemzLoMF62qOaiUQlgnsCwH5fRCD/00gsWCwg106pnbkmK4AyabyxzneOV4dfecDJWkSxw==",
 			"dev": true
 		},
 		"node_modules/@cspell/dict-bash": {
@@ -211,15 +212,15 @@
 			"dev": true
 		},
 		"node_modules/@cspell/dict-companies": {
-			"version": "3.0.31",
-			"resolved": "https://registry.npmjs.org/@cspell/dict-companies/-/dict-companies-3.0.31.tgz",
-			"integrity": "sha512-hKVpV/lcGKP4/DpEPS8P4osPvFH/YVLJaDn9cBIOH6/HSmL5LbFgJNKpMGaYRbhm2FEX56MKE3yn/MNeNYuesQ==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-companies/-/dict-companies-3.1.0.tgz",
+			"integrity": "sha512-02ic++LZsINvMdPJwoczQDxyb4nYyFGNETRjbz/4rsfEsWPmAhDO2e5VWR9jftlL8rdfbqWO/NVoCRmdmhn1vQ==",
 			"dev": true
 		},
 		"node_modules/@cspell/dict-cpp": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@cspell/dict-cpp/-/dict-cpp-5.1.3.tgz",
-			"integrity": "sha512-sqnriXRAInZH9W75C+APBh6dtben9filPqVbIsiRMUXGg+s02ekz0z6LbS7kXeJ5mD2qXoMLBrv13qH2eIwutQ==",
+			"version": "5.1.6",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-cpp/-/dict-cpp-5.1.6.tgz",
+			"integrity": "sha512-ich5C0DSc6qK74ZR373G3E/ySuIjxi8FDxDZNO4zGkHGUimhJ4TNUbz/8Yhv7No2hqXojBrywJTNBW5go1IA8w==",
 			"dev": true
 		},
 		"node_modules/@cspell/dict-cryptocurrencies": {
@@ -265,9 +266,9 @@
 			"dev": true
 		},
 		"node_modules/@cspell/dict-dotnet": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/@cspell/dict-dotnet/-/dict-dotnet-5.0.0.tgz",
-			"integrity": "sha512-EOwGd533v47aP5QYV8GlSSKkmM9Eq8P3G/eBzSpH3Nl2+IneDOYOBLEUraHuiCtnOkNsz0xtZHArYhAB2bHWAw==",
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-dotnet/-/dict-dotnet-5.0.2.tgz",
+			"integrity": "sha512-UD/pO2A2zia/YZJ8Kck/F6YyDSpCMq0YvItpd4YbtDVzPREfTZ48FjZsbYi4Jhzwfvc6o8R56JusAE58P+4sNQ==",
 			"dev": true
 		},
 		"node_modules/@cspell/dict-elixir": {
@@ -277,15 +278,15 @@
 			"dev": true
 		},
 		"node_modules/@cspell/dict-en_us": {
-			"version": "4.3.19",
-			"resolved": "https://registry.npmjs.org/@cspell/dict-en_us/-/dict-en_us-4.3.19.tgz",
-			"integrity": "sha512-tHcXdkmm0t9LlRct1vgu3+h0KW/wlXCInkTiR4D/rl730q1zu2qVEgiy1saMiTUSNmdu7Hiy+Mhb+1braVqnZQ==",
+			"version": "4.3.20",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-en_us/-/dict-en_us-4.3.20.tgz",
+			"integrity": "sha512-xxjV+iA+eoDtFPUhN7G42kvGBBCR4nxCv31Uo9mr/EjwsBqKcskTewcWRD7o4Vy66hppkXOayH2jWw8orD4/9g==",
 			"dev": true
 		},
 		"node_modules/@cspell/dict-en-common-misspellings": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@cspell/dict-en-common-misspellings/-/dict-en-common-misspellings-2.0.0.tgz",
-			"integrity": "sha512-NOg8dlv37/YqLkCfBs5OXeJm/Wcfb/CzeOmOZJ2ZXRuxwsNuolb4TREUce0yAXRqMhawahY5TSDRJJBgKjBOdw==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-en-common-misspellings/-/dict-en-common-misspellings-2.0.1.tgz",
+			"integrity": "sha512-uWaP8UG4uvcPyqaG0FzPKCm5kfmhsiiQ45Fs6b3/AEAqfq7Fj1JW0+S3qRt85FQA9SoU6gUJCz9wkK/Ylh7m5A==",
 			"dev": true
 		},
 		"node_modules/@cspell/dict-en-gb": {
@@ -295,9 +296,9 @@
 			"dev": true
 		},
 		"node_modules/@cspell/dict-filetypes": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/@cspell/dict-filetypes/-/dict-filetypes-3.0.3.tgz",
-			"integrity": "sha512-J9UP+qwwBLfOQ8Qg9tAsKtSY/WWmjj21uj6zXTI9hRLD1eG1uUOLcfVovAmtmVqUWziPSKMr87F6SXI3xmJXgw==",
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-filetypes/-/dict-filetypes-3.0.4.tgz",
+			"integrity": "sha512-IBi8eIVdykoGgIv5wQhOURi5lmCNJq0we6DvqKoPQJHthXbgsuO1qrHSiUVydMiQl/XvcnUWTMeAlVUlUClnVg==",
 			"dev": true
 		},
 		"node_modules/@cspell/dict-fonts": {
@@ -313,9 +314,9 @@
 			"dev": true
 		},
 		"node_modules/@cspell/dict-fullstack": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/@cspell/dict-fullstack/-/dict-fullstack-3.1.5.tgz",
-			"integrity": "sha512-6ppvo1dkXUZ3fbYn/wwzERxCa76RtDDl5Afzv2lijLoijGGUw5yYdLBKJnx8PJBGNLh829X352ftE7BElG4leA==",
+			"version": "3.1.8",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-fullstack/-/dict-fullstack-3.1.8.tgz",
+			"integrity": "sha512-YRlZupL7uqMCtEBK0bDP9BrcPnjDhz7m4GBqCc1EYqfXauHbLmDT8ELha7T/E7wsFKniHSjzwDZzhNXo2lusRQ==",
 			"dev": true
 		},
 		"node_modules/@cspell/dict-gaming-terms": {
@@ -331,9 +332,15 @@
 			"dev": true
 		},
 		"node_modules/@cspell/dict-golang": {
-			"version": "6.0.5",
-			"resolved": "https://registry.npmjs.org/@cspell/dict-golang/-/dict-golang-6.0.5.tgz",
-			"integrity": "sha512-w4mEqGz4/wV+BBljLxduFNkMrd3rstBNDXmoX5kD4UTzIb4Sy0QybWCtg2iVT+R0KWiRRA56QKOvBsgXiddksA==",
+			"version": "6.0.9",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-golang/-/dict-golang-6.0.9.tgz",
+			"integrity": "sha512-etDt2WQauyEQDA+qPS5QtkYTb2I9l5IfQftAllVoB1aOrT6bxxpHvMEpJ0Hsn/vezxrCqa/BmtUbRxllIxIuSg==",
+			"dev": true
+		},
+		"node_modules/@cspell/dict-google": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-google/-/dict-google-1.0.0.tgz",
+			"integrity": "sha512-qE6lqSXvyCZUR3H9GNqIyDVs6k/adHSxgQDrAze3M1O9AAsLqJqedTzzu6HzgcCKggonkxSGMP3i2mZBRUDgnQ==",
 			"dev": true
 		},
 		"node_modules/@cspell/dict-haskell": {
@@ -367,9 +374,9 @@
 			"dev": true
 		},
 		"node_modules/@cspell/dict-k8s": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@cspell/dict-k8s/-/dict-k8s-1.0.2.tgz",
-			"integrity": "sha512-tLT7gZpNPnGa+IIFvK9SP1LrSpPpJ94a/DulzAPOb1Q2UBFwdpFd82UWhio0RNShduvKG/WiMZf/wGl98pn+VQ==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-k8s/-/dict-k8s-1.0.3.tgz",
+			"integrity": "sha512-dR58QCcsOYeOoPT+d3kUPrEQ9FQ62cohLHqPu4kiWvsrLszEUMopjGu3p5tVnq496M+RY5PLlbLLaW9ixHmFOQ==",
 			"dev": true
 		},
 		"node_modules/@cspell/dict-latex": {
@@ -409,21 +416,21 @@
 			"dev": true
 		},
 		"node_modules/@cspell/dict-npm": {
-			"version": "5.0.15",
-			"resolved": "https://registry.npmjs.org/@cspell/dict-npm/-/dict-npm-5.0.15.tgz",
-			"integrity": "sha512-sX0X5YWNW54F4baW7b5JJB6705OCBIZtUqjOghlJNORS5No7QY1IX1zc5FxNNu4gsaCZITAmfMi4ityXEsEThA==",
+			"version": "5.0.16",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-npm/-/dict-npm-5.0.16.tgz",
+			"integrity": "sha512-ZWPnLAziEcSCvV0c8k9Qj88pfMu+wZwM5Qks87ShsfBgI8uLZ9tGHravA7gmjH1Gd7Bgxy2ulvXtSqIWPh1lew==",
 			"dev": true
 		},
 		"node_modules/@cspell/dict-php": {
-			"version": "4.0.6",
-			"resolved": "https://registry.npmjs.org/@cspell/dict-php/-/dict-php-4.0.6.tgz",
-			"integrity": "sha512-ySAXisf7twoVFZqBV2o/DKiCLIDTHNqfnj0EfH9OoOUR7HL3rb6zJkm0viLUFDO2G/8SyIi6YrN/6KX+Scjjjg==",
+			"version": "4.0.7",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-php/-/dict-php-4.0.7.tgz",
+			"integrity": "sha512-SUCOBfRDDFz1E2jnAZIIuy8BNbCc8i+VkiL9g4HH9tTN6Nlww5Uz2pMqYS6rZQkXuubqsbkbPlsRiuseEnTmYA==",
 			"dev": true
 		},
 		"node_modules/@cspell/dict-powershell": {
-			"version": "5.0.3",
-			"resolved": "https://registry.npmjs.org/@cspell/dict-powershell/-/dict-powershell-5.0.3.tgz",
-			"integrity": "sha512-lEdzrcyau6mgzu1ie98GjOEegwVHvoaWtzQnm1ie4DyZgMr+N6D0Iyj1lzvtmt0snvsDFa5F2bsYzf3IMKcpcA==",
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-powershell/-/dict-powershell-5.0.4.tgz",
+			"integrity": "sha512-eosDShapDgBWN9ULF7+sRNdUtzRnUdsfEdBSchDm8FZA4HOqxUSZy3b/cX/Rdw0Fnw0AKgk0kzgXw7tS6vwJMQ==",
 			"dev": true
 		},
 		"node_modules/@cspell/dict-public-licenses": {
@@ -460,15 +467,15 @@
 			"dev": true
 		},
 		"node_modules/@cspell/dict-scala": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/@cspell/dict-scala/-/dict-scala-5.0.0.tgz",
-			"integrity": "sha512-ph0twaRoV+ylui022clEO1dZ35QbeEQaKTaV2sPOsdwIokABPIiK09oWwGK9qg7jRGQwVaRPEq0Vp+IG1GpqSQ==",
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-scala/-/dict-scala-5.0.2.tgz",
+			"integrity": "sha512-v97ClgidZt99JUm7OjhQugDHmhx4U8fcgunHvD/BsXWjXNj4cTr0m0YjofyZoL44WpICsNuFV9F/sv9OM5HUEw==",
 			"dev": true
 		},
 		"node_modules/@cspell/dict-software-terms": {
-			"version": "3.3.20",
-			"resolved": "https://registry.npmjs.org/@cspell/dict-software-terms/-/dict-software-terms-3.3.20.tgz",
-			"integrity": "sha512-KmPwCxYWEu7SGyT/0m/n6i6R4ZgxbmN3XcerzA6Z629Wm5iZTVfJaMWqDK2RKAyBawS7OMfxGz0W/wYU4FhJlA==",
+			"version": "3.3.23",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-software-terms/-/dict-software-terms-3.3.23.tgz",
+			"integrity": "sha512-KhxpZEAhzFOsvUWOrN4gg/jC6HVoyvkLiV5VGWbFt4vvEEXPogBZbeT6UTQIvFTwSVu65rZxGrswaIHBZ/RoaQ==",
 			"dev": true
 		},
 		"node_modules/@cspell/dict-sql": {
@@ -496,9 +503,9 @@
 			"dev": true
 		},
 		"node_modules/@cspell/dict-typescript": {
-			"version": "3.1.4",
-			"resolved": "https://registry.npmjs.org/@cspell/dict-typescript/-/dict-typescript-3.1.4.tgz",
-			"integrity": "sha512-jUcPa0rsPca5ur1+G56DXnSc5hbbJkzvPHHvyQtkbPXBQd3CXPMNfrTVCgzex/7cY/7FONcpFCUwgwfni9Jqbw==",
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-typescript/-/dict-typescript-3.1.5.tgz",
+			"integrity": "sha512-EkIwwNV/xqEoBPJml2S16RXj65h1kvly8dfDLgXerrKw6puybZdvAHerAph6/uPTYdtLcsPyJYkPt5ISOJYrtw==",
 			"dev": true
 		},
 		"node_modules/@cspell/dict-vue": {
@@ -508,9 +515,9 @@
 			"dev": true
 		},
 		"node_modules/@cspell/dynamic-import": {
-			"version": "8.8.0",
-			"resolved": "https://registry.npmjs.org/@cspell/dynamic-import/-/dynamic-import-8.8.0.tgz",
-			"integrity": "sha512-oNe8IPaTDsbfGbGCt7Ss+g8RRI7c9zpTnp/G/eG+PuWvH8Isps4+dWE/4qhxS7e3XTyQwfD89b3H3TAPAuwstQ==",
+			"version": "8.8.3",
+			"resolved": "https://registry.npmjs.org/@cspell/dynamic-import/-/dynamic-import-8.8.3.tgz",
+			"integrity": "sha512-qpxGC2hGVfbSaLJkaEu//rqbgAOjYnMlbxD75Fk9ny96sr+ZI1YC0nmUErWlgXSbtjVY/DHCOu26Usweo5iRgA==",
 			"dev": true,
 			"dependencies": {
 				"import-meta-resolve": "^4.1.0"
@@ -520,13 +527,13 @@
 			}
 		},
 		"node_modules/@cspell/eslint-plugin": {
-			"version": "8.8.0",
-			"resolved": "https://registry.npmjs.org/@cspell/eslint-plugin/-/eslint-plugin-8.8.0.tgz",
-			"integrity": "sha512-4yIQgwC/kLoHRHunxU62X5Y0ORyCoQNhN86rXHOGL3OyAVxaudiwevyG7XL4fe6NjrPNIeQMUHXHXVI9+W0C7Q==",
+			"version": "8.8.3",
+			"resolved": "https://registry.npmjs.org/@cspell/eslint-plugin/-/eslint-plugin-8.8.3.tgz",
+			"integrity": "sha512-N32SkoOa9DoUkfhsaGHg2mZHYUx8Tt0M4d34UAnbbqYEFwYP6wfrAzMhX35vicX1kh1KHeoSUsr5PukUhx8GzQ==",
 			"dev": true,
 			"dependencies": {
-				"@cspell/cspell-types": "8.8.0",
-				"cspell-lib": "8.8.0",
+				"@cspell/cspell-types": "8.8.3",
+				"cspell-lib": "8.8.3",
 				"estree-walker": "^3.0.3",
 				"synckit": "^0.9.0"
 			},
@@ -538,9 +545,9 @@
 			}
 		},
 		"node_modules/@cspell/strong-weak-map": {
-			"version": "8.8.0",
-			"resolved": "https://registry.npmjs.org/@cspell/strong-weak-map/-/strong-weak-map-8.8.0.tgz",
-			"integrity": "sha512-A0mkSdPiZkbF3e+OGM2eO1k0yrdgohvgO2p3fhb1bGylj8n6po+H6iNh2zpumTtfy1xVIrfpYPdOT7Z6TvvbIw==",
+			"version": "8.8.3",
+			"resolved": "https://registry.npmjs.org/@cspell/strong-weak-map/-/strong-weak-map-8.8.3.tgz",
+			"integrity": "sha512-y/pL7Zex8iHQ54qDYvg9oCiCgfZ9DAUTOI/VtPFVC+42JqLx6YufYxJS2uAsFlfAXIPiRV8qnnG6BHImD1Ix6g==",
 			"dev": true,
 			"engines": {
 				"node": ">=18"
@@ -1366,28 +1373,28 @@
 			]
 		},
 		"node_modules/@sveltejs/adapter-auto": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-auto/-/adapter-auto-3.2.0.tgz",
-			"integrity": "sha512-She5nKT47kwHE18v9NMe6pbJcvULr82u0V3yZ0ej3n1laWKGgkgdEABE9/ak5iDPs93LqsBkuIo51kkwCLBjJA==",
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-auto/-/adapter-auto-3.2.1.tgz",
+			"integrity": "sha512-/3xx8ZFCD5UBc/7AbyXkFF3HNCzWAp2xncH8HA4doGjoGQEN7PmwiRx4Y9nOzi4mqDqYYUic0gaIAE2khWWU4Q==",
 			"dev": true,
 			"dependencies": {
-				"import-meta-resolve": "^4.0.0"
+				"import-meta-resolve": "^4.1.0"
 			},
 			"peerDependencies": {
 				"@sveltejs/kit": "^2.0.0"
 			}
 		},
 		"node_modules/@sveltejs/kit": {
-			"version": "2.5.7",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.5.7.tgz",
-			"integrity": "sha512-6uedTzrb7nQrw6HALxnPrPaXdIN2jJJTzTIl96Z3P5NiG+OAfpdPbrWrvkJ3GN4CfWqrmU4dJqwMMRMTD/C7ow==",
+			"version": "2.5.10",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.5.10.tgz",
+			"integrity": "sha512-OqoyTmFG2cYmCFAdBfW+Qxbg8m23H4dv6KqwEt7ofr/ROcfcIl3Z/VT56L22H9f0uNZyr+9Bs1eh2gedOCK9kA==",
 			"hasInstallScript": true,
 			"dependencies": {
 				"@types/cookie": "^0.6.0",
 				"cookie": "^0.6.0",
 				"devalue": "^5.0.0",
 				"esm-env": "^1.0.0",
-				"import-meta-resolve": "^4.0.0",
+				"import-meta-resolve": "^4.1.0",
 				"kleur": "^4.1.5",
 				"magic-string": "^0.30.5",
 				"mrmime": "^2.0.0",
@@ -1409,9 +1416,9 @@
 			}
 		},
 		"node_modules/@sveltejs/package": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/@sveltejs/package/-/package-2.3.0.tgz",
-			"integrity": "sha512-wmtwEfi3gQnmtotAjygRHR6cmLfpblQl1dU764f3N2I5DPe34llFs44bHOYcuk91Bp2sSq6bWUmNwxGlYCchOA==",
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/@sveltejs/package/-/package-2.3.1.tgz",
+			"integrity": "sha512-JvR2J4ost1oCn1CSdqenYRwGX/1RX+7LN+VZ71aPnz3JAlIFaEKQd1pBxlb+OSQTfeugJO0W39gB9voAbBO5ow==",
 			"dev": true,
 			"dependencies": {
 				"chokidar": "^3.6.0",
@@ -1431,16 +1438,16 @@
 			}
 		},
 		"node_modules/@sveltejs/vite-plugin-svelte": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-3.0.2.tgz",
-			"integrity": "sha512-MpmF/cju2HqUls50WyTHQBZUV3ovV/Uk8k66AN2gwHogNAG8wnW8xtZDhzNBsFJJuvmq1qnzA5kE7YfMJNFv2Q==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-3.1.0.tgz",
+			"integrity": "sha512-sY6ncCvg+O3njnzbZexcVtUqOBE3iYmQPJ9y+yXSkOwG576QI/xJrBnQSRXFLGwJNBa0T78JEKg5cIR0WOAuUw==",
 			"dependencies": {
 				"@sveltejs/vite-plugin-svelte-inspector": "^2.0.0",
 				"debug": "^4.3.4",
 				"deepmerge": "^4.3.1",
 				"kleur": "^4.1.5",
-				"magic-string": "^0.30.5",
-				"svelte-hmr": "^0.15.3",
+				"magic-string": "^0.30.9",
+				"svelte-hmr": "^0.16.0",
 				"vitefu": "^0.2.5"
 			},
 			"engines": {
@@ -1499,28 +1506,20 @@
 			"integrity": "sha512-Sk/uYFOBAB7mb74XcpizmH0KOR2Pv3D2Hmrh1Dmy5BmK3MpdSa5kqZcg6EKBdklU0bFXX9gCfzvpnyUehrPIuA==",
 			"dev": true
 		},
-		"node_modules/@types/semver": {
-			"version": "7.5.8",
-			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
-			"integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
-			"dev": true
-		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "7.8.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.8.0.tgz",
-			"integrity": "sha512-gFTT+ezJmkwutUPmB0skOj3GZJtlEGnlssems4AjkVweUPGj7jRwwqg0Hhg7++kPGJqKtTYx+R05Ftww372aIg==",
+			"version": "7.10.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.10.0.tgz",
+			"integrity": "sha512-PzCr+a/KAef5ZawX7nbyNwBDtM1HdLIT53aSA2DDlxmxMngZ43O8SIePOeX8H5S+FHXeI6t97mTt/dDdzY4Fyw==",
 			"dev": true,
 			"dependencies": {
 				"@eslint-community/regexpp": "^4.10.0",
-				"@typescript-eslint/scope-manager": "7.8.0",
-				"@typescript-eslint/type-utils": "7.8.0",
-				"@typescript-eslint/utils": "7.8.0",
-				"@typescript-eslint/visitor-keys": "7.8.0",
-				"debug": "^4.3.4",
+				"@typescript-eslint/scope-manager": "7.10.0",
+				"@typescript-eslint/type-utils": "7.10.0",
+				"@typescript-eslint/utils": "7.10.0",
+				"@typescript-eslint/visitor-keys": "7.10.0",
 				"graphemer": "^1.4.0",
 				"ignore": "^5.3.1",
 				"natural-compare": "^1.4.0",
-				"semver": "^7.6.0",
 				"ts-api-utils": "^1.3.0"
 			},
 			"engines": {
@@ -1541,15 +1540,15 @@
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "7.8.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.8.0.tgz",
-			"integrity": "sha512-KgKQly1pv0l4ltcftP59uQZCi4HUYswCLbTqVZEJu7uLX8CTLyswqMLqLN+2QFz4jCptqWVV4SB7vdxcH2+0kQ==",
+			"version": "7.10.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.10.0.tgz",
+			"integrity": "sha512-2EjZMA0LUW5V5tGQiaa2Gys+nKdfrn2xiTIBLR4fxmPmVSvgPcKNW+AE/ln9k0A4zDUti0J/GZXMDupQoI+e1w==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "7.8.0",
-				"@typescript-eslint/types": "7.8.0",
-				"@typescript-eslint/typescript-estree": "7.8.0",
-				"@typescript-eslint/visitor-keys": "7.8.0",
+				"@typescript-eslint/scope-manager": "7.10.0",
+				"@typescript-eslint/types": "7.10.0",
+				"@typescript-eslint/typescript-estree": "7.10.0",
+				"@typescript-eslint/visitor-keys": "7.10.0",
 				"debug": "^4.3.4"
 			},
 			"engines": {
@@ -1569,13 +1568,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "7.8.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.8.0.tgz",
-			"integrity": "sha512-viEmZ1LmwsGcnr85gIq+FCYI7nO90DVbE37/ll51hjv9aG+YZMb4WDE2fyWpUR4O/UrhGRpYXK/XajcGTk2B8g==",
+			"version": "7.10.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.10.0.tgz",
+			"integrity": "sha512-7L01/K8W/VGl7noe2mgH0K7BE29Sq6KAbVmxurj8GGaPDZXPr8EEQ2seOeAS+mEV9DnzxBQB6ax6qQQ5C6P4xg==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "7.8.0",
-				"@typescript-eslint/visitor-keys": "7.8.0"
+				"@typescript-eslint/types": "7.10.0",
+				"@typescript-eslint/visitor-keys": "7.10.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || >=20.0.0"
@@ -1586,13 +1585,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "7.8.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.8.0.tgz",
-			"integrity": "sha512-H70R3AefQDQpz9mGv13Uhi121FNMh+WEaRqcXTX09YEDky21km4dV1ZXJIp8QjXc4ZaVkXVdohvWDzbnbHDS+A==",
+			"version": "7.10.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.10.0.tgz",
+			"integrity": "sha512-D7tS4WDkJWrVkuzgm90qYw9RdgBcrWmbbRkrLA4d7Pg3w0ttVGDsvYGV19SH8gPR5L7OtcN5J1hTtyenO9xE9g==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/typescript-estree": "7.8.0",
-				"@typescript-eslint/utils": "7.8.0",
+				"@typescript-eslint/typescript-estree": "7.10.0",
+				"@typescript-eslint/utils": "7.10.0",
 				"debug": "^4.3.4",
 				"ts-api-utils": "^1.3.0"
 			},
@@ -1613,9 +1612,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "7.8.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.8.0.tgz",
-			"integrity": "sha512-wf0peJ+ZGlcH+2ZS23aJbOv+ztjeeP8uQ9GgwMJGVLx/Nj9CJt17GWgWWoSmoRVKAX2X+7fzEnAjxdvK2gqCLw==",
+			"version": "7.10.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.10.0.tgz",
+			"integrity": "sha512-7fNj+Ya35aNyhuqrA1E/VayQX9Elwr8NKZ4WueClR3KwJ7Xx9jcCdOrLW04h51de/+gNbyFMs+IDxh5xIwfbNg==",
 			"dev": true,
 			"engines": {
 				"node": "^18.18.0 || >=20.0.0"
@@ -1626,13 +1625,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "7.8.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.8.0.tgz",
-			"integrity": "sha512-5pfUCOwK5yjPaJQNy44prjCwtr981dO8Qo9J9PwYXZ0MosgAbfEMB008dJ5sNo3+/BN6ytBPuSvXUg9SAqB0dg==",
+			"version": "7.10.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.10.0.tgz",
+			"integrity": "sha512-LXFnQJjL9XIcxeVfqmNj60YhatpRLt6UhdlFwAkjNc6jSUlK8zQOl1oktAP8PlWFzPQC1jny/8Bai3/HPuvN5g==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "7.8.0",
-				"@typescript-eslint/visitor-keys": "7.8.0",
+				"@typescript-eslint/types": "7.10.0",
+				"@typescript-eslint/visitor-keys": "7.10.0",
 				"debug": "^4.3.4",
 				"globby": "^11.1.0",
 				"is-glob": "^4.0.3",
@@ -1654,18 +1653,15 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "7.8.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.8.0.tgz",
-			"integrity": "sha512-L0yFqOCflVqXxiZyXrDr80lnahQfSOfc9ELAAZ75sqicqp2i36kEZZGuUymHNFoYOqxRT05up760b4iGsl02nQ==",
+			"version": "7.10.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.10.0.tgz",
+			"integrity": "sha512-olzif1Fuo8R8m/qKkzJqT7qwy16CzPRWBvERS0uvyc+DHd8AKbO4Jb7kpAvVzMmZm8TrHnI7hvjN4I05zow+tg==",
 			"dev": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.4.0",
-				"@types/json-schema": "^7.0.15",
-				"@types/semver": "^7.5.8",
-				"@typescript-eslint/scope-manager": "7.8.0",
-				"@typescript-eslint/types": "7.8.0",
-				"@typescript-eslint/typescript-estree": "7.8.0",
-				"semver": "^7.6.0"
+				"@typescript-eslint/scope-manager": "7.10.0",
+				"@typescript-eslint/types": "7.10.0",
+				"@typescript-eslint/typescript-estree": "7.10.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || >=20.0.0"
@@ -1679,12 +1675,12 @@
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "7.8.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.8.0.tgz",
-			"integrity": "sha512-q4/gibTNBQNA0lGyYQCmWRS5D15n8rXh4QjK3KV+MBPlTYHpfBUT3D3PaPR/HeNiI9W6R7FvlkcGhNyAoP+caA==",
+			"version": "7.10.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.10.0.tgz",
+			"integrity": "sha512-9ntIVgsi6gg6FIq9xjEO4VQJvwOqA3jaBFQJ/6TK5AvEup2+cECI6Fh7QiBxmfMHXU0V0J4RyPeOU1VDNzl9cg==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "7.8.0",
+				"@typescript-eslint/types": "7.10.0",
 				"eslint-visitor-keys": "^3.4.3"
 			},
 			"engines": {
@@ -1702,9 +1698,9 @@
 			"dev": true
 		},
 		"node_modules/@vercel/analytics": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-1.2.2.tgz",
-			"integrity": "sha512-X0rctVWkQV1e5Y300ehVNqpOfSOufo7ieA5PIdna8yX/U7Vjz0GFsGf4qvAhxV02uQ2CVt7GYcrFfddXXK2Y4A==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-1.3.0.tgz",
+			"integrity": "sha512-iAeQhNwL2kGUVbx6Z43uT+PG19Bn7IUOGWB9Z4jmWAyL/Jn6v+KHmZj0fSFCcxN1YXU9xkjKpuD/6YlJmzN06A==",
 			"dependencies": {
 				"server-only": "^0.0.1"
 			},
@@ -1930,11 +1926,11 @@
 			}
 		},
 		"node_modules/braces": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-			"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+			"integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
 			"dependencies": {
-				"fill-range": "^7.0.1"
+				"fill-range": "^7.1.1"
 			},
 			"engines": {
 				"node": ">=8"
@@ -2177,25 +2173,6 @@
 			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
 			"dev": true
 		},
-		"node_modules/configstore": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/configstore/-/configstore-6.0.0.tgz",
-			"integrity": "sha512-cD31W1v3GqUlQvbBCGcXmd2Nj9SvLDOP1oQ0YFuLETufzSPaKp11rYBsSOm7rCsW3OnIRAFM3OxRhceaXNYHkA==",
-			"dev": true,
-			"dependencies": {
-				"dot-prop": "^6.0.1",
-				"graceful-fs": "^4.2.6",
-				"unique-string": "^3.0.0",
-				"write-file-atomic": "^3.0.3",
-				"xdg-basedir": "^5.0.1"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/yeoman/configstore?sponsor=1"
-			}
-		},
 		"node_modules/cookie": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
@@ -2223,40 +2200,13 @@
 				"node": ">= 8"
 			}
 		},
-		"node_modules/crypto-random-string": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-4.0.0.tgz",
-			"integrity": "sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA==",
-			"dev": true,
-			"dependencies": {
-				"type-fest": "^1.0.1"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/crypto-random-string/node_modules/type-fest": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
-			"integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/cspell-config-lib": {
-			"version": "8.8.0",
-			"resolved": "https://registry.npmjs.org/cspell-config-lib/-/cspell-config-lib-8.8.0.tgz",
-			"integrity": "sha512-Sz+bKXV9qpEVdi0e+MSUVMwbJ5Kin3m+6tyJp/Rk2rXKjBIXVmFBmnixv964rhr6c5GzbblV7GuMn94B2p7B3Q==",
+			"version": "8.8.3",
+			"resolved": "https://registry.npmjs.org/cspell-config-lib/-/cspell-config-lib-8.8.3.tgz",
+			"integrity": "sha512-61NKZrzTi9OLEEiZBggLQy9nswgR0gd6bKH06xXFQyRfNpAjaPOzOUFhSSfX1MQX+lQF3KtSYcHpppwbpPsL8w==",
 			"dev": true,
 			"dependencies": {
-				"@cspell/cspell-types": "8.8.0",
+				"@cspell/cspell-types": "8.8.3",
 				"comment-json": "^4.2.3",
 				"yaml": "^2.4.2"
 			},
@@ -2277,14 +2227,14 @@
 			}
 		},
 		"node_modules/cspell-dictionary": {
-			"version": "8.8.0",
-			"resolved": "https://registry.npmjs.org/cspell-dictionary/-/cspell-dictionary-8.8.0.tgz",
-			"integrity": "sha512-Iloe3GBJV3sVkZG0j0rmxwuNxIcuOHy+eLhFfSHKiLK62FyOBL3T2Rm50h2Q6fCiLONu/3CNp0Z3BKbQ8cZxZg==",
+			"version": "8.8.3",
+			"resolved": "https://registry.npmjs.org/cspell-dictionary/-/cspell-dictionary-8.8.3.tgz",
+			"integrity": "sha512-g2G3uh8JbuJKAYFdFQENcbTIrK9SJRXBiQ/t+ch+9I/t5HmuGOVe+wxKEM/0c9M2CRLpzJShBvttH9rnw4Yqfg==",
 			"dev": true,
 			"dependencies": {
-				"@cspell/cspell-pipe": "8.8.0",
-				"@cspell/cspell-types": "8.8.0",
-				"cspell-trie-lib": "8.8.0",
+				"@cspell/cspell-pipe": "8.8.3",
+				"@cspell/cspell-types": "8.8.3",
+				"cspell-trie-lib": "8.8.3",
 				"fast-equals": "^5.0.1",
 				"gensequence": "^7.0.0"
 			},
@@ -2293,25 +2243,25 @@
 			}
 		},
 		"node_modules/cspell-glob": {
-			"version": "8.8.0",
-			"resolved": "https://registry.npmjs.org/cspell-glob/-/cspell-glob-8.8.0.tgz",
-			"integrity": "sha512-LAq4PrE92vvuKoIbZN6B6HqmNlSEw9yds6pkmugYYpd6vLMBvzMbtTGjIEq0o+KhfoJPOnfOxRssPoiezwvIhA==",
+			"version": "8.8.3",
+			"resolved": "https://registry.npmjs.org/cspell-glob/-/cspell-glob-8.8.3.tgz",
+			"integrity": "sha512-9c4Nw/bIsjKSuBuRrLa1sWtIzbXXvja+FVbUOE9c2IiZfh6K1I+UssiXTbRTMg6qgTdkfT4o3KOcFN0ZcbmCUQ==",
 			"dev": true,
 			"dependencies": {
-				"micromatch": "^4.0.5"
+				"micromatch": "^4.0.7"
 			},
 			"engines": {
 				"node": ">=18"
 			}
 		},
 		"node_modules/cspell-grammar": {
-			"version": "8.8.0",
-			"resolved": "https://registry.npmjs.org/cspell-grammar/-/cspell-grammar-8.8.0.tgz",
-			"integrity": "sha512-sB9IvSQ89Q5TgmAwXwXubs5U8dfZFvvaMT5LGKKW/XMGO4gVSBTAwRwGP2INZXdHHzFXUaVhEd+Tf4S3djoOdw==",
+			"version": "8.8.3",
+			"resolved": "https://registry.npmjs.org/cspell-grammar/-/cspell-grammar-8.8.3.tgz",
+			"integrity": "sha512-3RP7xQ/6IiIjbWQDuE+4b0ERKkSWGMY75bd0oEsh5HcFhhOYphmcpxLxRRM/yxYQaYgdvq0QIcwrpanx86KJ7A==",
 			"dev": true,
 			"dependencies": {
-				"@cspell/cspell-pipe": "8.8.0",
-				"@cspell/cspell-types": "8.8.0"
+				"@cspell/cspell-pipe": "8.8.3",
+				"@cspell/cspell-types": "8.8.3"
 			},
 			"bin": {
 				"cspell-grammar": "bin.mjs"
@@ -2321,44 +2271,45 @@
 			}
 		},
 		"node_modules/cspell-io": {
-			"version": "8.8.0",
-			"resolved": "https://registry.npmjs.org/cspell-io/-/cspell-io-8.8.0.tgz",
-			"integrity": "sha512-98sPDQiwLTI3eNqGe6ksJv6ue5BJCMjM6CDF686Sxx2GlYe50saJK1XizM1yuhBcaHPZysSYHzbsLTMb7aSzWQ==",
+			"version": "8.8.3",
+			"resolved": "https://registry.npmjs.org/cspell-io/-/cspell-io-8.8.3.tgz",
+			"integrity": "sha512-vO7BUa6i7tjmQr+9dw/Ic7tm4ECnSUlbuMv0zJs/SIrO9AcID2pCWPeZNZEGAmeutrEOi2iThZ/uS33aCuv7Jw==",
 			"dev": true,
 			"dependencies": {
-				"@cspell/cspell-service-bus": "8.8.0"
+				"@cspell/cspell-service-bus": "8.8.3"
 			},
 			"engines": {
 				"node": ">=18"
 			}
 		},
 		"node_modules/cspell-lib": {
-			"version": "8.8.0",
-			"resolved": "https://registry.npmjs.org/cspell-lib/-/cspell-lib-8.8.0.tgz",
-			"integrity": "sha512-P6WBilxNOXFWBgAFtTJn8VIBgBwn39v/TuA7d9uUWiRI/bhcMddEMCwVyjSZ3YYW/OmDEyN/c+R/4HjOw1Ny8A==",
+			"version": "8.8.3",
+			"resolved": "https://registry.npmjs.org/cspell-lib/-/cspell-lib-8.8.3.tgz",
+			"integrity": "sha512-IqtTKBPug5Jzt9T8f/b6qGAbARRR5tpQkLjzsrfLzxM68ery23wEPDtmWToEyc9EslulZGLe0T78XuEU9AMF+g==",
 			"dev": true,
 			"dependencies": {
-				"@cspell/cspell-bundled-dicts": "8.8.0",
-				"@cspell/cspell-pipe": "8.8.0",
-				"@cspell/cspell-resolver": "8.8.0",
-				"@cspell/cspell-types": "8.8.0",
-				"@cspell/dynamic-import": "8.8.0",
-				"@cspell/strong-weak-map": "8.8.0",
+				"@cspell/cspell-bundled-dicts": "8.8.3",
+				"@cspell/cspell-pipe": "8.8.3",
+				"@cspell/cspell-resolver": "8.8.3",
+				"@cspell/cspell-types": "8.8.3",
+				"@cspell/dynamic-import": "8.8.3",
+				"@cspell/strong-weak-map": "8.8.3",
 				"clear-module": "^4.1.2",
 				"comment-json": "^4.2.3",
-				"configstore": "^6.0.0",
-				"cspell-config-lib": "8.8.0",
-				"cspell-dictionary": "8.8.0",
-				"cspell-glob": "8.8.0",
-				"cspell-grammar": "8.8.0",
-				"cspell-io": "8.8.0",
-				"cspell-trie-lib": "8.8.0",
+				"cspell-config-lib": "8.8.3",
+				"cspell-dictionary": "8.8.3",
+				"cspell-glob": "8.8.3",
+				"cspell-grammar": "8.8.3",
+				"cspell-io": "8.8.3",
+				"cspell-trie-lib": "8.8.3",
+				"env-paths": "^3.0.0",
 				"fast-equals": "^5.0.1",
 				"gensequence": "^7.0.0",
 				"import-fresh": "^3.3.0",
 				"resolve-from": "^5.0.0",
 				"vscode-languageserver-textdocument": "^1.0.11",
-				"vscode-uri": "^3.0.8"
+				"vscode-uri": "^3.0.8",
+				"xdg-basedir": "^5.1.0"
 			},
 			"engines": {
 				"node": ">=18"
@@ -2374,13 +2325,13 @@
 			}
 		},
 		"node_modules/cspell-trie-lib": {
-			"version": "8.8.0",
-			"resolved": "https://registry.npmjs.org/cspell-trie-lib/-/cspell-trie-lib-8.8.0.tgz",
-			"integrity": "sha512-0UJp2Y5QMaBdapyIWtZ5DTH9BlM0tMcAYxOeqwmbnsdyfe2Ix8w9Ur3ZSQAAVnHEFhPJA83D0D1rMsKdYdQ4zQ==",
+			"version": "8.8.3",
+			"resolved": "https://registry.npmjs.org/cspell-trie-lib/-/cspell-trie-lib-8.8.3.tgz",
+			"integrity": "sha512-0zrkrhrFLVajwo6++XD9a+r0Olml7UjPgbztjPKbXIJrZCradBF5rvt3wq5mPpsjq2+Dz0z6K5muZpbO+gqapQ==",
 			"dev": true,
 			"dependencies": {
-				"@cspell/cspell-pipe": "8.8.0",
-				"@cspell/cspell-types": "8.8.0",
+				"@cspell/cspell-pipe": "8.8.3",
+				"@cspell/cspell-types": "8.8.3",
 				"gensequence": "^7.0.0"
 			},
 			"engines": {
@@ -2502,21 +2453,6 @@
 				"node": ">=6.0.0"
 			}
 		},
-		"node_modules/dot-prop": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-6.0.1.tgz",
-			"integrity": "sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==",
-			"dev": true,
-			"dependencies": {
-				"is-obj": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/eastasianwidth": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -2531,6 +2467,18 @@
 			"version": "9.2.2",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
 			"integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="
+		},
+		"node_modules/env-paths": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
+			"integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
+			"dev": true,
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
 		},
 		"node_modules/es6-promise": {
 			"version": "3.3.1",
@@ -2678,9 +2626,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-svelte": {
-			"version": "2.38.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-svelte/-/eslint-plugin-svelte-2.38.0.tgz",
-			"integrity": "sha512-IwwxhHzitx3dr0/xo0z4jjDlb2AAHBPKt+juMyKKGTLlKi1rZfA4qixMwnveU20/JTHyipM6keX4Vr7LZFYc9g==",
+			"version": "2.39.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-svelte/-/eslint-plugin-svelte-2.39.0.tgz",
+			"integrity": "sha512-FXktBLXsrxbA+6ZvJK2z/sQOrUKyzSg3fNWK5h0reSCjr2fjAsc9ai/s/JvSl4Hgvz3nYVtTIMwarZH5RcB7BA==",
 			"dev": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.4.0",
@@ -2688,13 +2636,13 @@
 				"debug": "^4.3.4",
 				"eslint-compat-utils": "^0.5.0",
 				"esutils": "^2.0.3",
-				"known-css-properties": "^0.30.0",
+				"known-css-properties": "^0.31.0",
 				"postcss": "^8.4.38",
 				"postcss-load-config": "^3.1.4",
 				"postcss-safe-parser": "^6.0.0",
 				"postcss-selector-parser": "^6.0.16",
 				"semver": "^7.6.0",
-				"svelte-eslint-parser": ">=0.35.0 <1.0.0"
+				"svelte-eslint-parser": ">=0.36.0 <1.0.0"
 			},
 			"engines": {
 				"node": "^14.17.0 || >=16.0.0"
@@ -2922,9 +2870,9 @@
 			}
 		},
 		"node_modules/fill-range": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-			"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+			"integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
 			"dependencies": {
 				"to-regex-range": "^5.0.1"
 			},
@@ -3323,15 +3271,6 @@
 				"node": ">=0.12.0"
 			}
 		},
-		"node_modules/is-obj": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
-			"integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/is-path-inside": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
@@ -3348,12 +3287,6 @@
 			"dependencies": {
 				"@types/estree": "*"
 			}
-		},
-		"node_modules/is-typedarray": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-			"integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
-			"dev": true
 		},
 		"node_modules/isexe": {
 			"version": "2.0.0",
@@ -3433,9 +3366,9 @@
 			}
 		},
 		"node_modules/known-css-properties": {
-			"version": "0.30.0",
-			"resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.30.0.tgz",
-			"integrity": "sha512-VSWXYUnsPu9+WYKkfmJyLKtIvaRJi1kXUqVmBACORXZQxT5oZDsoZ2vQP+bQFDnWtpI/4eq3MLoRMjI2fnLzTQ==",
+			"version": "0.31.0",
+			"resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.31.0.tgz",
+			"integrity": "sha512-sBPIUGTNF0czz0mwGGUoKKJC8Q7On1GPbCSFPfyEsfHb2DyBG0Y4QtV+EVWpINSaiGKZblDNuF5AezxSgOhesQ==",
 			"dev": true
 		},
 		"node_modules/levn": {
@@ -3512,14 +3445,11 @@
 			}
 		},
 		"node_modules/magic-string": {
-			"version": "0.30.5",
-			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.5.tgz",
-			"integrity": "sha512-7xlpfBaQaP/T6Vh8MO/EqXSW5En6INHEvEXQiuff7Gku0PWjU3uf6w/j9o7O+SpB5fOAkrI5HeoNgwjEO0pFsA==",
+			"version": "0.30.10",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.10.tgz",
+			"integrity": "sha512-iIRwTIf0QKV3UAnYK4PU8uiEc4SRh5jX0mwpIwETPpHdhVM4f53RSwS/vXvN1JhGX+Cs7B8qIq3d6AH49O5fAQ==",
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.4.15"
-			},
-			"engines": {
-				"node": ">=12"
 			}
 		},
 		"node_modules/mdn-data": {
@@ -3536,11 +3466,11 @@
 			}
 		},
 		"node_modules/micromatch": {
-			"version": "4.0.5",
-			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-			"integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+			"version": "4.0.7",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.7.tgz",
+			"integrity": "sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==",
 			"dependencies": {
-				"braces": "^3.0.2",
+				"braces": "^3.0.3",
 				"picomatch": "^2.3.1"
 			},
 			"engines": {
@@ -4122,9 +4052,9 @@
 			}
 		},
 		"node_modules/prettier-plugin-svelte": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/prettier-plugin-svelte/-/prettier-plugin-svelte-3.2.2.tgz",
-			"integrity": "sha512-ZzzE/wMuf48/1+Lf2Ffko0uDa6pyCfgHV6+uAhtg2U0AAXGrhCSW88vEJNAkAxW5qyrFY1y1zZ4J8TgHrjW++Q==",
+			"version": "3.2.3",
+			"resolved": "https://registry.npmjs.org/prettier-plugin-svelte/-/prettier-plugin-svelte-3.2.3.tgz",
+			"integrity": "sha512-wJq8RunyFlWco6U0WJV5wNCM7zpBFakS76UBSbmzMGpncpK98NZABaE+s7n8/APDCEVNHXC5Mpq+MLebQtsRlg==",
 			"dev": true,
 			"peerDependencies": {
 				"prettier": "^3.0.0",
@@ -4721,9 +4651,9 @@
 			}
 		},
 		"node_modules/svelte": {
-			"version": "4.2.16",
-			"resolved": "https://registry.npmjs.org/svelte/-/svelte-4.2.16.tgz",
-			"integrity": "sha512-mQwHpqHD2PmFcCyHaZ7XiTqposaLvJ75WpYcyY5/ce3qxbYtwQpZ+M7ZKP+2CG5U6kfnBZBpPLyofhlE6ROrnQ==",
+			"version": "4.2.17",
+			"resolved": "https://registry.npmjs.org/svelte/-/svelte-4.2.17.tgz",
+			"integrity": "sha512-N7m1YnoXtRf5wya5Gyx3TWuTddI4nAyayyIWFojiWV5IayDYNV5i2mRp/7qNGol4DtxEYxljmrbgp1HM6hUbmQ==",
 			"dependencies": {
 				"@ampproject/remapping": "^2.2.1",
 				"@jridgewell/sourcemap-codec": "^1.4.15",
@@ -4767,9 +4697,9 @@
 			}
 		},
 		"node_modules/svelte-eslint-parser": {
-			"version": "0.35.0",
-			"resolved": "https://registry.npmjs.org/svelte-eslint-parser/-/svelte-eslint-parser-0.35.0.tgz",
-			"integrity": "sha512-CtbPseajW0gjwEvHiuzYJkPDjAcHz2FaHt540j6RVYrZgnE6xWkzUBodQ4I3nV+G5AS0Svt8K6aIA/CIU9xT2Q==",
+			"version": "0.36.0",
+			"resolved": "https://registry.npmjs.org/svelte-eslint-parser/-/svelte-eslint-parser-0.36.0.tgz",
+			"integrity": "sha512-/6YmUSr0FAVxW8dXNdIMydBnddPMHzaHirAZ7RrT21XYdgGGZMh0LQG6CZsvAFS4r2Y4ItUuCQc8TQ3urB30mQ==",
 			"dev": true,
 			"dependencies": {
 				"eslint-scope": "^7.2.2",
@@ -4785,7 +4715,7 @@
 				"url": "https://github.com/sponsors/ota-meshi"
 			},
 			"peerDependencies": {
-				"svelte": "^3.37.0 || ^4.0.0 || ^5.0.0-next.112"
+				"svelte": "^3.37.0 || ^4.0.0 || ^5.0.0-next.115"
 			},
 			"peerDependenciesMeta": {
 				"svelte": {
@@ -4794,9 +4724,9 @@
 			}
 		},
 		"node_modules/svelte-hmr": {
-			"version": "0.15.3",
-			"resolved": "https://registry.npmjs.org/svelte-hmr/-/svelte-hmr-0.15.3.tgz",
-			"integrity": "sha512-41snaPswvSf8TJUhlkoJBekRrABDXDMdpNpT2tfHIv4JuhgvHqLMhEPGtaQn0BmbNSTkuz2Ed20DF2eHw0SmBQ==",
+			"version": "0.16.0",
+			"resolved": "https://registry.npmjs.org/svelte-hmr/-/svelte-hmr-0.16.0.tgz",
+			"integrity": "sha512-Gyc7cOS3VJzLlfj7wKS0ZnzDVdv3Pn2IuVeJPk9m2skfhcu5bq3wtIZyQGggr7/Iim5rH5cncyQft/kRLupcnA==",
 			"engines": {
 				"node": "^12.20 || ^14.13.1 || >= 16"
 			},
@@ -5114,19 +5044,10 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/typedarray-to-buffer": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
-			"integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
-			"dev": true,
-			"dependencies": {
-				"is-typedarray": "^1.0.0"
-			}
-		},
 		"node_modules/typescript": {
-			"version": "5.4.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.3.tgz",
-			"integrity": "sha512-KrPd3PKaCLr78MalgiwJnA25Nm8HAmdwN3mYUYZgG/wizIo9EainNVQI9/yDavtVFRN2h3k8uf3GLHuhDMgEHg==",
+			"version": "5.4.5",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+			"integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
 			"dev": true,
 			"bin": {
 				"tsc": "bin/tsc",
@@ -5134,21 +5055,6 @@
 			},
 			"engines": {
 				"node": ">=14.17"
-			}
-		},
-		"node_modules/unique-string": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/unique-string/-/unique-string-3.0.0.tgz",
-			"integrity": "sha512-VGXBUVwxKMBUznyffQweQABPRRW1vHZAbadFZud4pLFAqRGvv/96vafgjWFqzourzr8YonlQiPgH0YCJfawoGQ==",
-			"dev": true,
-			"dependencies": {
-				"crypto-random-string": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/update-browserslist-db": {
@@ -5378,24 +5284,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-			"dev": true
-		},
-		"node_modules/write-file-atomic": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
-			"integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
-			"dev": true,
-			"dependencies": {
-				"imurmurhash": "^0.1.4",
-				"is-typedarray": "^1.0.0",
-				"signal-exit": "^3.0.2",
-				"typedarray-to-buffer": "^3.1.5"
-			}
-		},
-		"node_modules/write-file-atomic/node_modules/signal-exit": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
 			"dev": true
 		},
 		"node_modules/xdg-basedir": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "geist-ui-svelte",
-	"version": "0.7.5",
+	"version": "0.7.6",
 	"author": {
 		"name": "Aidan Bleser",
 		"url": "https://aidanbleser.com"
@@ -328,23 +328,23 @@
 		"svelte": "^4.0.0"
 	},
 	"devDependencies": {
-		"@cspell/eslint-plugin": "^8.8.0",
-		"@sveltejs/adapter-auto": "^3.2.0",
-		"@sveltejs/package": "^2.3.0",
-		"@sveltejs/vite-plugin-svelte": "^3.0.2",
+		"@cspell/eslint-plugin": "^8.8.3",
+		"@sveltejs/adapter-auto": "^3.2.1",
+		"@sveltejs/package": "^2.3.1",
+		"@sveltejs/vite-plugin-svelte": "^3.1.0",
 		"@types/eslint": "^8.56.10",
-		"@typescript-eslint/eslint-plugin": "^7.8.0",
-		"@typescript-eslint/parser": "^7.8.0",
+		"@typescript-eslint/eslint-plugin": "^7.10.0",
+		"@typescript-eslint/parser": "^7.10.0",
 		"eslint": "^8.57.0",
 		"eslint-config-prettier": "^9.1.0",
-		"eslint-plugin-svelte": "^2.38.0",
+		"eslint-plugin-svelte": "^2.39.0",
 		"prettier": "^3.2.5",
-		"prettier-plugin-svelte": "^3.2.2",
+		"prettier-plugin-svelte": "^3.2.3",
 		"publint": "^0.1.9",
-		"svelte": "^4.2.16",
+		"svelte": "^4.2.17",
 		"svelte-check": "^3.7.1",
 		"tslib": "^2.4.1",
-		"typescript": "^5.4.3",
+		"typescript": "^5.4.5",
 		"vite": "^5.2.11"
 	},
 	"svelte": "./dist/index.js",
@@ -353,8 +353,8 @@
 	"dependencies": {
 		"@fontsource/geist-mono": "^5.0.3",
 		"@fontsource/geist-sans": "^5.0.3",
-		"@sveltejs/kit": "^2.5.7",
-		"@vercel/analytics": "^1.2.2",
+		"@sveltejs/kit": "^2.5.10",
+		"@vercel/analytics": "^1.3.0",
 		"@vercel/speed-insights": "^1.0.10",
 		"autoprefixer": "^10.4.19",
 		"class-variance-authority": "^0.7.0",

--- a/src/lib/tabs/TabItem.svelte
+++ b/src/lib/tabs/TabItem.svelte
@@ -11,11 +11,15 @@
 	export let disabled: boolean = false;
 	export let activeForSubdirectories = true;
 
+	$: isHash = href ? href.startsWith("#") : false;
+
 	$: to = href ? trimLink(href) : null;
 
 	$: active =
 		href === $page.url.pathname ||
-		(activeForSubdirectories && $page.url.pathname.startsWith(href ?? ""));
+		(activeForSubdirectories && $page.url.pathname.startsWith(href ?? "")) ||
+		(isHash &&
+			($page.url.hash == href || ((href == "#" || href == "#/") && $page.url.hash == "")));
 
 	const trimLink = (link: string) => {
 		if (link[link.length - 1] == "/") {
@@ -47,11 +51,7 @@
 	};
 
 	const clicked = (e: MouseEvent) => {
-		const target = e.target as HTMLAnchorElement;
-
-		if (disabled) return;
-
-		goto(target.href);
+		if (disabled) e.preventDefault();
 	};
 </script>
 
@@ -66,21 +66,19 @@
 		on:click={select}
 		{disabled}
 		role="tab"
-		aria-selected={selected}
-	>
+		aria-selected={selected}>
 		<slot />
 	</button>
 {:else}
 	<a
 		{href}
-		on:click|preventDefault={clicked}
+		on:click={clicked}
 		data-active={active}
 		aria-disabled={disabled}
 		class="z-[1] flex place-items-center justify-center px-3 py-3 text-sm text-gray-500
 	transition-all hover:text-black data-[active=true]:text-black dark:text-gray-500 aria-disabled:hover:cursor-not-allowed
 	aria-disabled:!text-gray-300 aria-disabled:dark:!text-gray-700 dark:data-[active=true]:text-white
-	dark:data-[active=false]:hover:text-white text-nowrap outline-none focus:outline-none"
-	>
+	dark:data-[active=false]:hover:text-white text-nowrap outline-none focus:outline-none">
 		<slot />
 	</a>
 {/if}

--- a/src/lib/tabs/TabItem.svelte
+++ b/src/lib/tabs/TabItem.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { goto } from "$app/navigation";
 	import { page } from "$app/stores";
 	import { createEventDispatcher } from "svelte";
 
@@ -66,7 +65,8 @@
 		on:click={select}
 		{disabled}
 		role="tab"
-		aria-selected={selected}>
+		aria-selected={selected}
+	>
 		<slot />
 	</button>
 {:else}
@@ -78,7 +78,8 @@
 		class="z-[1] flex place-items-center justify-center px-3 py-3 text-sm text-gray-500
 	transition-all hover:text-black data-[active=true]:text-black dark:text-gray-500 aria-disabled:hover:cursor-not-allowed
 	aria-disabled:!text-gray-300 aria-disabled:dark:!text-gray-700 dark:data-[active=true]:text-white
-	dark:data-[active=false]:hover:text-white text-nowrap outline-none focus:outline-none">
+	dark:data-[active=false]:hover:text-white text-nowrap outline-none focus:outline-none"
+	>
 		<slot />
 	</a>
 {/if}

--- a/src/routes/components/hero/+page.svelte
+++ b/src/routes/components/hero/+page.svelte
@@ -40,7 +40,8 @@
 		<Button color="secondary-light">Get Started</Button>
 		<Button>Components</Button>
 	</div>
-</Hero>`}>
+</Hero>`}
+>
 	<Button on:click={() => (firstExamplePage = true)}>Show Example</Button>
 	<Page bind:visible={firstExamplePage}>
 		<div class="max-h-screen overflow-y-auto">
@@ -53,7 +54,8 @@
 				</div>
 				<Spacer h={150} />
 				<Button on:click={() => (firstExamplePage = false)}
-					>Click here to close or press `Escape`</Button>
+					>Click here to close or press `Escape`</Button
+				>
 			</Hero>
 		</div>
 	</Page>
@@ -71,7 +73,8 @@
 		<Button color="secondary-light">Get Started</Button>
 		<Button>Components</Button>
 	</div>
-</Hero>`}>
+</Hero>`}
+>
 	<Button on:click={() => (secondExamplePage = true)}>Show Example</Button>
 	<Page bind:visible={secondExamplePage}>
 		<div class="max-h-screen overflow-y-auto">
@@ -84,7 +87,8 @@
 				</div>
 				<Spacer h={150} />
 				<Button on:click={() => (secondExamplePage = false)}
-					>Click here to close or press `Escape`</Button>
+					>Click here to close or press `Escape`</Button
+				>
 			</Hero>
 		</div>
 	</Page>
@@ -115,7 +119,8 @@
 	<Button on:click={() => (thirdExamplePage = false)}
 		>Click here to close or press \`Escape\`</Button
 		>
-</Hero>`}>
+</Hero>`}
+>
 	<Button on:click={() => (thirdExamplePage = true)}>Show Example</Button>
 	<Page bind:visible={thirdExamplePage}>
 		<div class="max-h-screen overflow-y-auto">
@@ -135,7 +140,8 @@
 				</div>
 				<Spacer h={150} />
 				<Button on:click={() => (thirdExamplePage = false)}
-					>Click here to close or press `Escape`</Button>
+					>Click here to close or press `Escape`</Button
+				>
 			</Hero>
 		</div>
 	</Page>
@@ -145,7 +151,8 @@
 <Spacer h={5} />
 <Text>
 	Sometimes you want your hero section to account for a header use the <code
-		>`exclusionHeight`</code>
+		>`exclusionHeight`</code
+	>
 	to calculate the height of the header and subtract it from the 100svh. This can also be useful if
 	you have footers or other content that should take space from the hero section.
 </Text>
@@ -170,7 +177,8 @@
 	<Spacer h={150} />
 	<Button on:click={() => (fourthExamplePage = false)}
 		>Click here to close or press \`Escape\`</Button>
-</Hero>`}>
+</Hero>`}
+>
 	<Button on:click={() => (fourthExamplePage = true)}>Show Example</Button>
 	<Page bind:visible={fourthExamplePage}>
 		<div class="max-h-screen overflow-y-auto">
@@ -189,7 +197,8 @@
 				</div>
 				<Spacer h={150} />
 				<Button on:click={() => (fourthExamplePage = false)}
-					>Click here to close or press `Escape`</Button>
+					>Click here to close or press `Escape`</Button
+				>
 			</Hero>
 		</div>
 	</Page>
@@ -217,23 +226,20 @@
 	<Button on:click={() => centered = !centered}>
 		Toggle Centered
 	</Button>
-</Hero>`}>
+</Hero>`}
+>
 	<Button on:click={() => (fifthExamplePage = true)}>Show Example</Button>
 	<Page bind:visible={fifthExamplePage}>
 		<div class="max-h-screen overflow-y-auto">
 			<Header sticky>
 				<div class="flex place-items-center justify-between w-full px-6 max-w-5xl">
 					<Text type="h5">geist-ui-svelte</Text>
-					<Button on:click={() => (fifthExamplePage = false)}>
-						Click to close
-					</Button>
+					<Button on:click={() => (fifthExamplePage = false)}>Click to close</Button>
 				</div>
 			</Header>
 			<Hero exclusionHeight={53} trueCenter={centered}>
 				<Text align="center" type="h1">Centered</Text>
-				<Button on:click={() => centered = !centered}>
-					Toggle Centered
-				</Button>
+				<Button on:click={() => (centered = !centered)}>Toggle Centered</Button>
 			</Hero>
 		</div>
 	</Page>

--- a/src/routes/components/tabs/+page.svelte
+++ b/src/routes/components/tabs/+page.svelte
@@ -7,6 +7,7 @@
 	import GithubIcon from "$lib/icons/GithubIcon.svelte";
 	import SvelteIcon from "$lib/icons/SvelteIcon.svelte";
 	import Playground from "$lib/docs-components/playground/playground.svelte";
+	import { page } from "$app/stores";
 </script>
 
 <Text type="h3">Tabs</Text>
@@ -16,8 +17,7 @@
 <Snippet
 	width="500px"
 	type="transparent"
-	text={`import { Tabs, TabItem } from 'geist-ui-svelte';`}
-/>
+	text={`import { Tabs, TabItem } from 'geist-ui-svelte';`} />
 <Spacer h={30} />
 <Text type="h4">Basic</Text>
 <Spacer h={10} />
@@ -26,8 +26,7 @@
 	<TabItem>Home</TabItem>
 	<TabItem initialSelected={true}>Guide</TabItem>
 	<TabItem>Components</TabItem>
-</Tabs>`}
->
+</Tabs>`}>
 	<Tabs>
 		<TabItem>Home</TabItem>
 		<TabItem initialSelected={true}>Guide</TabItem>
@@ -42,8 +41,7 @@
 	<TabItem>Home</TabItem>
 	<TabItem initialSelected={true}>Guide</TabItem>
 	<TabItem>Components</TabItem>
-</Tabs>`}
->
+</Tabs>`}>
 	<Tabs>
 		<TabItem initialSelected={true}>Home</TabItem>
 		<TabItem>Guide</TabItem>
@@ -60,8 +58,7 @@
 	<TabItem>Home</TabItem>
 	<TabItem initialSelected={true}>Guide</TabItem>
 	<TabItem>Components</TabItem>
-</Tabs>`}
->
+</Tabs>`}>
 	<Tabs border={false}>
 		<TabItem>Home</TabItem>
 		<TabItem initialSelected={true}>Guide</TabItem>
@@ -89,8 +86,7 @@
 	<TabItem>Account</TabItem>
 	<TabItem>About</TabItem>
 	<TabItem>Contact Us</TabItem>
-</Tabs>`}
->
+</Tabs>`}>
 	<Tabs>
 		<TabItem initialSelected={true}>Home</TabItem>
 		<TabItem>Guide</TabItem>
@@ -122,8 +118,7 @@
 		<Spacer w={10} />
 		Svelte
 	</TabItem>
-</Tabs>`}
->
+</Tabs>`}>
 	<Tabs>
 		<TabItem initialSelected={true}>
 			<GithubIcon size={16} />
@@ -158,11 +153,54 @@
 	<TabItem href="/components/avatar">
 		Avatar
 	</TabItem>
-</Tabs>`}
->
+</Tabs>`}>
 	<Tabs>
 		<TabItem href="/components/tabs">Tabs</TabItem>
 		<TabItem href="/components/badge">Badge</TabItem>
 		<TabItem href="/components/avatar">Avatar</TabItem>
 	</Tabs>
+</Playground>
+<Spacer h={30} />
+<Text type="h4">Using <Text serif>`#`</Text></Text>
+<Spacer h={5} />
+<Text>
+	Tabs pattern matching is made so that its easy to use <code>`#`</code> this allows you to maintain
+	your tab state even through refresh.
+</Text>
+<Spacer h={10} />
+<Playground
+	code={`<Tabs>
+	<!-- 
+		You can use '#/' to prevent scroll 
+		while still being the default tab 
+	-->
+	<TabItem href="#/">Materials</TabItem>
+	<TabItem href="#assignees">Assignees</TabItem>
+	<TabItem href="#time-logs">Time Logs</TabItem>
+	<TabItem href="#scheduling" disabled>Scheduling</TabItem>
+</Tabs>
+{#if $page.url.hash == '#/' || $page.url.hash == ""}
+	materials
+{:else if $page.url.hash == '#assignees'}
+	assignees
+{:else if $page.url.hash == '#time-logs'}
+	time logs
+{:else if $page.url.hash == '#scheduling'}
+	scheduling
+{/if}`}>
+	<Tabs>
+		<TabItem href="#/">Materials</TabItem>
+		<TabItem href="#assignees">Assignees</TabItem>
+		<TabItem href="#time-logs">Time Logs</TabItem>
+		<TabItem href="#scheduling" disabled>Scheduling</TabItem>
+	</Tabs>
+	{#if $page.url.hash == "#/" || $page.url.hash == ""}
+		materials
+	{:else if $page.url.hash == "#assignees"}
+		assignees
+	{:else if $page.url.hash == "#time-logs"}
+		time logs
+	{:else if $page.url.hash == "#scheduling"}
+		scheduling
+	{/if}
 </Playground>

--- a/src/routes/components/tabs/+page.svelte
+++ b/src/routes/components/tabs/+page.svelte
@@ -17,7 +17,8 @@
 <Snippet
 	width="500px"
 	type="transparent"
-	text={`import { Tabs, TabItem } from 'geist-ui-svelte';`} />
+	text={`import { Tabs, TabItem } from 'geist-ui-svelte';`}
+/>
 <Spacer h={30} />
 <Text type="h4">Basic</Text>
 <Spacer h={10} />
@@ -26,7 +27,8 @@
 	<TabItem>Home</TabItem>
 	<TabItem initialSelected={true}>Guide</TabItem>
 	<TabItem>Components</TabItem>
-</Tabs>`}>
+</Tabs>`}
+>
 	<Tabs>
 		<TabItem>Home</TabItem>
 		<TabItem initialSelected={true}>Guide</TabItem>
@@ -41,7 +43,8 @@
 	<TabItem>Home</TabItem>
 	<TabItem initialSelected={true}>Guide</TabItem>
 	<TabItem>Components</TabItem>
-</Tabs>`}>
+</Tabs>`}
+>
 	<Tabs>
 		<TabItem initialSelected={true}>Home</TabItem>
 		<TabItem>Guide</TabItem>
@@ -58,7 +61,8 @@
 	<TabItem>Home</TabItem>
 	<TabItem initialSelected={true}>Guide</TabItem>
 	<TabItem>Components</TabItem>
-</Tabs>`}>
+</Tabs>`}
+>
 	<Tabs border={false}>
 		<TabItem>Home</TabItem>
 		<TabItem initialSelected={true}>Guide</TabItem>
@@ -86,7 +90,8 @@
 	<TabItem>Account</TabItem>
 	<TabItem>About</TabItem>
 	<TabItem>Contact Us</TabItem>
-</Tabs>`}>
+</Tabs>`}
+>
 	<Tabs>
 		<TabItem initialSelected={true}>Home</TabItem>
 		<TabItem>Guide</TabItem>
@@ -118,7 +123,8 @@
 		<Spacer w={10} />
 		Svelte
 	</TabItem>
-</Tabs>`}>
+</Tabs>`}
+>
 	<Tabs>
 		<TabItem initialSelected={true}>
 			<GithubIcon size={16} />
@@ -153,7 +159,8 @@
 	<TabItem href="/components/avatar">
 		Avatar
 	</TabItem>
-</Tabs>`}>
+</Tabs>`}
+>
 	<Tabs>
 		<TabItem href="/components/tabs">Tabs</TabItem>
 		<TabItem href="/components/badge">Badge</TabItem>
@@ -187,7 +194,8 @@
 	time logs
 {:else if $page.url.hash == '#scheduling'}
 	scheduling
-{/if}`}>
+{/if}`}
+>
 	<Tabs>
 		<TabItem href="#/">Materials</TabItem>
 		<TabItem href="#assignees">Assignees</TabItem>


### PR DESCRIPTION
## Description

You could do this before but pattern matching wouldn't work because it was based on the pathname

### Breaking changes

None

## Checks 🗸

-   [x] My code is up to date with main
-   [x] My code requires a documentation change
-   [x] I have updated the documentation as required
-   [x] My code requires a new package version to be created
-   [ ] I have updated the package version
-   [ ] CI is passing
-   [ ] The vercel deployment is passing and the page is working as expected
